### PR TITLE
Added Python v3 support for TraCI

### DIFF
--- a/sumo/tools/traci/areal.py
+++ b/sumo/tools/traci/areal.py
@@ -17,7 +17,6 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
 

--- a/sumo/tools/traci/edge.py
+++ b/sumo/tools/traci/edge.py
@@ -17,9 +17,9 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
 
 _RETURN_VALUE_FUNC = {tc.ID_LIST:                   traci.Storage.readStringList,
                       tc.ID_COUNT:                  traci.Storage.readInt,
@@ -75,7 +75,7 @@ def getAdaptedTraveltime(edgeID, time):
     """
     traci._beginMessage(tc.CMD_GET_EDGE_VARIABLE, tc.VAR_EDGE_TRAVELTIME,
                         edgeID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER,
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER,
                                          traci._TIME2STEPS(time))
     return traci._checkResult(tc.CMD_GET_EDGE_VARIABLE,
                               tc.VAR_EDGE_TRAVELTIME, edgeID).readDouble()
@@ -97,7 +97,7 @@ def getEffort(edgeID, time):
     """
     traci._beginMessage(tc.CMD_GET_EDGE_VARIABLE, tc.VAR_EDGE_EFFORT,
                         edgeID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER,
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER,
                                          traci._TIME2STEPS(time))
     return traci._checkResult(tc.CMD_GET_EDGE_VARIABLE,
                               tc.VAR_EDGE_EFFORT, edgeID).readDouble()
@@ -271,7 +271,7 @@ def adaptTraveltime(edgeID, time):
     """
     traci._beginMessage(
         tc.CMD_SET_EDGE_VARIABLE, tc.VAR_EDGE_TRAVELTIME, edgeID, 1 + 4 + 1 + 8)
-    traci._message.string += struct.pack("!BiBd",
+    traci._message.string += struct_pack("!BiBd",
                                          tc.TYPE_COMPOUND, 1, tc.TYPE_DOUBLE, time)
     traci._sendExact()
 
@@ -283,7 +283,7 @@ def setEffort(edgeID, effort):
     """
     traci._beginMessage(
         tc.CMD_SET_EDGE_VARIABLE, tc.VAR_EDGE_EFFORT, edgeID, 1 + 4 + 1 + 8)
-    traci._message.string += struct.pack("!BiBd",
+    traci._message.string += struct_pack("!BiBd",
                                          tc.TYPE_COMPOUND, 1, tc.TYPE_DOUBLE, effort)
     traci._sendExact()
 

--- a/sumo/tools/traci/gui.py
+++ b/sumo/tools/traci/gui.py
@@ -17,9 +17,10 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
+
 
 DEFAULT_VIEW = 'View #0'
 _RETURN_VALUE_FUNC = {tc.ID_LIST:           traci.Storage.readStringList,
@@ -122,7 +123,7 @@ def setOffset(viewID, x, y):
     """
     traci._beginMessage(
         tc.CMD_SET_GUI_VARIABLE, tc.VAR_VIEW_OFFSET, viewID, 1 + 8 + 8)
-    traci._message.string += struct.pack("!Bdd", tc.POSITION_2D, x, y)
+    traci._message.string += struct_pack("!Bdd", tc.POSITION_2D, x, y)
     traci._sendExact()
 
 
@@ -142,7 +143,7 @@ def setBoundary(viewID, xmin, ymin, xmax, ymax):
     """
     traci._beginMessage(
         tc.CMD_SET_GUI_VARIABLE, tc.VAR_VIEW_BOUNDARY, viewID, 1 + 8 + 8 + 8 + 8)
-    traci._message.string += struct.pack("!Bdddd",
+    traci._message.string += struct_pack("!Bdddd",
                                          tc.TYPE_BOUNDINGBOX, xmin, ymin, xmax, ymax)
     traci._sendExact()
 

--- a/sumo/tools/traci/lane.py
+++ b/sumo/tools/traci/lane.py
@@ -19,9 +19,9 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
 
 
 def _readLinks(result):
@@ -342,10 +342,10 @@ def setAllowed(laneID, allowedClasses):
         allowedClasses = [allowedClasses]
     traci._beginMessage(tc.CMD_SET_LANE_VARIABLE, tc.LANE_ALLOWED, laneID,
                         1 + 4 + sum(map(len, allowedClasses)) + 4 * len(allowedClasses))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRINGLIST, len(allowedClasses))
     for c in allowedClasses:
-        traci._message.string += struct.pack("!i", len(c)) + str(c)
+        traci._message.string += struct_pack("!i", len(c)) + str(c)
     traci._sendExact()
 
 
@@ -358,10 +358,10 @@ def setDisallowed(laneID, disallowedClasses):
         disallowedClasses = [disallowedClasses]
     traci._beginMessage(tc.CMD_SET_LANE_VARIABLE, tc.LANE_DISALLOWED, laneID,
                         1 + 4 + sum(map(len, disallowedClasses)) + 4 * len(disallowedClasses))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRINGLIST, len(disallowedClasses))
     for c in disallowedClasses:
-        traci._message.string += struct.pack("!i", len(c)) + str(c)
+        traci._message.string += struct_pack("!i", len(c)) + str(c)
     traci._sendExact()
 
 

--- a/sumo/tools/traci/person.py
+++ b/sumo/tools/traci/person.py
@@ -16,7 +16,6 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
 

--- a/sumo/tools/traci/poi.py
+++ b/sumo/tools/traci/poi.py
@@ -17,9 +17,10 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
+
 
 _RETURN_VALUE_FUNC = {tc.ID_LIST:      traci.Storage.readStringList,
                       tc.ID_COUNT:     traci.Storage.readInt,
@@ -111,7 +112,7 @@ def setType(poiID, poiType):
     """
     traci._beginMessage(
         tc.CMD_SET_POI_VARIABLE, tc.VAR_TYPE, poiID, 1 + 4 + len(poiType))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(poiType)) + str(poiType)
     traci._sendExact()
 
@@ -123,7 +124,7 @@ def setPosition(poiID, x, y):
     """
     traci._beginMessage(
         tc.CMD_SET_POI_VARIABLE, tc.VAR_POSITION, poiID, 1 + 8 + 8)
-    traci._message.string += struct.pack("!Bdd", tc.POSITION_2D, x, y)
+    traci._message.string += struct_pack("!Bdd", tc.POSITION_2D, x, y)
     traci._sendExact()
 
 
@@ -134,7 +135,7 @@ def setColor(poiID, color):
     """
     traci._beginMessage(
         tc.CMD_SET_POI_VARIABLE, tc.VAR_COLOR, poiID, 1 + 1 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
     traci._sendExact()
 
@@ -142,19 +143,19 @@ def setColor(poiID, color):
 def add(poiID, x, y, color, poiType="", layer=0):
     traci._beginMessage(tc.CMD_SET_POI_VARIABLE, tc.ADD, poiID, 1 +
                         4 + 1 + 4 + len(poiType) + 1 + 1 + 1 + 1 + 1 + 1 + 4 + 1 + 8 + 8)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 4)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 4)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(poiType)) + str(poiType)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, layer)
-    traci._message.string += struct.pack("!Bdd", tc.POSITION_2D, x, y)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, layer)
+    traci._message.string += struct_pack("!Bdd", tc.POSITION_2D, x, y)
     traci._sendExact()
 
 
 def remove(poiID, layer=0):
     traci._beginMessage(tc.CMD_SET_POI_VARIABLE, tc.REMOVE, poiID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, layer)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, layer)
     traci._sendExact()
 
 

--- a/sumo/tools/traci/polygon.py
+++ b/sumo/tools/traci/polygon.py
@@ -16,9 +16,10 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
+
 
 _RETURN_VALUE_FUNC = {tc.ID_LIST:   traci.Storage.readStringList,
                       tc.ID_COUNT:  traci.Storage.readInt,
@@ -112,7 +113,7 @@ def setType(polygonID, polygonType):
     """
     traci._beginMessage(
         tc.CMD_SET_POLYGON_VARIABLE, tc.VAR_TYPE, polygonID, 1 + 4 + len(polygonType))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(polygonType)) + str(polygonType)
     traci._sendExact()
 
@@ -124,9 +125,9 @@ def setShape(polygonID, shape):
     """
     traci._beginMessage(tc.CMD_SET_POLYGON_VARIABLE,
                         tc.VAR_SHAPE, polygonID, 1 + 1 + len(shape) * (8 + 8))
-    traci._message.string += struct.pack("!BB", tc.TYPE_POLYGON, len(shape))
+    traci._message.string += struct_pack("!BB", tc.TYPE_POLYGON, len(shape))
     for p in shape:
-        traci._message.string += struct.pack("!dd", p)
+        traci._message.string += struct_pack("!dd", p)
     traci._sendExact()
 
 
@@ -137,7 +138,7 @@ def setColor(polygonID, color):
     """
     traci._beginMessage(
         tc.CMD_SET_POLYGON_VARIABLE, tc.VAR_COLOR, polygonID, 1 + 1 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
     traci._sendExact()
 
@@ -145,23 +146,23 @@ def setColor(polygonID, color):
 def add(polygonID, shape, color, fill=False, polygonType="", layer=0):
     traci._beginMessage(tc.CMD_SET_POLYGON_VARIABLE, tc.ADD, polygonID, 1 + 4 + 1 + 4 +
                         len(polygonType) + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 4 + 1 + 1 + len(shape) * (8 + 8))
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 5)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 5)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(polygonType)) + str(polygonType)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
-    traci._message.string += struct.pack("!BB", tc.TYPE_UBYTE, int(fill))
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, layer)
-    traci._message.string += struct.pack("!BB", tc.TYPE_POLYGON, len(shape))
+    traci._message.string += struct_pack("!BB", tc.TYPE_UBYTE, int(fill))
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, layer)
+    traci._message.string += struct_pack("!BB", tc.TYPE_POLYGON, len(shape))
     for p in shape:
-        traci._message.string += struct.pack("!dd", *p)
+        traci._message.string += struct_pack("!dd", *p)
     traci._sendExact()
 
 
 def remove(polygonID, layer=0):
     traci._beginMessage(
         tc.CMD_SET_POLYGON_VARIABLE, tc.REMOVE, polygonID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, layer)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, layer)
     traci._sendExact()
 
 

--- a/sumo/tools/traci/route.py
+++ b/sumo/tools/traci/route.py
@@ -18,8 +18,9 @@ the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
 import traci
-import struct
 import traci.constants as tc
+from traci import struct_pack
+
 
 _RETURN_VALUE_FUNC = {tc.ID_LIST:   traci.Storage.readStringList,
                       tc.ID_COUNT:  traci.Storage.readInt,
@@ -95,9 +96,9 @@ def add(routeID, edges):
     """
     traci._beginMessage(tc.CMD_SET_ROUTE_VARIABLE, tc.ADD, routeID,
                         1 + 4 + sum(map(len, edges)) + 4 * len(edges))
-    traci._message.string += struct.pack("!Bi", tc.TYPE_STRINGLIST, len(edges))
+    traci._message.string += struct_pack("!Bi", tc.TYPE_STRINGLIST, len(edges))
     for e in edges:
-        traci._message.string += struct.pack("!i", len(e)) + str(e)
+        traci._message.string += struct_pack("!i", len(e)) + str(e)
     traci._sendExact()
 
 

--- a/sumo/tools/traci/simulation.py
+++ b/sumo/tools/traci/simulation.py
@@ -19,7 +19,7 @@ the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
 import traci
-import struct
+from traci import struct_pack
 import traci.constants as tc
 
 _RETURN_VALUE_FUNC = {tc.VAR_TIME_STEP:                         traci.Storage.readInt,
@@ -248,10 +248,10 @@ def convert2D(edgeID, pos, laneIndex=0, toGeo=False):
         posType = tc.POSITION_LON_LAT
     traci._beginMessage(tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION,
                         "", 1 + 4 + 1 + 4 + len(edgeID) + 8 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 2)
+    traci._message.string += struct_pack("!Bi",
                                          tc.POSITION_ROADMAP, len(edgeID)) + edgeID
-    traci._message.string += struct.pack("!dBBB",
+    traci._message.string += struct_pack("!dBBB",
                                          pos, laneIndex, tc.TYPE_UBYTE, posType)
     return traci._checkResult(tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "").read("!dd")
 
@@ -262,10 +262,10 @@ def convert3D(edgeID, pos, laneIndex=0, toGeo=False):
         posType = tc.POSITION_LON_LAT_ALT
     traci._beginMessage(tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION,
                         "", 1 + 4 + 1 + 4 + len(edgeID) + 8 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 2)
+    traci._message.string += struct_pack("!Bi",
                                          tc.POSITION_ROADMAP, len(edgeID)) + edgeID
-    traci._message.string += struct.pack("!dBBB",
+    traci._message.string += struct_pack("!dBBB",
                                          pos, laneIndex, tc.TYPE_UBYTE, posType)
     return traci._checkResult(tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "").read("!ddd")
 
@@ -276,9 +276,9 @@ def convertRoad(x, y, isGeo=False):
         posType = tc.POSITION_LON_LAT
     traci._beginMessage(
         tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "", 1 + 4 + 1 + 8 + 8 + 1 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
-    traci._message.string += struct.pack("!Bdd", posType, x, y)
-    traci._message.string += struct.pack("!BB",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 2)
+    traci._message.string += struct_pack("!Bdd", posType, x, y)
+    traci._message.string += struct_pack("!BB",
                                          tc.TYPE_UBYTE, tc.POSITION_ROADMAP)
     result = traci._checkResult(
         tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "")
@@ -293,9 +293,9 @@ def convertGeo(x, y, fromGeo=False):
         toType = tc.POSITION_2D
     traci._beginMessage(
         tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "", 1 + 4 + 1 + 8 + 8 + 1 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
-    traci._message.string += struct.pack("!Bdd", fromType, x, y)
-    traci._message.string += struct.pack("!BB", tc.TYPE_UBYTE, toType)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 2)
+    traci._message.string += struct_pack("!Bdd", fromType, x, y)
+    traci._message.string += struct_pack("!BB", tc.TYPE_UBYTE, toType)
     return traci._checkResult(tc.CMD_GET_SIM_VARIABLE, tc.POSITION_CONVERSION, "").read("!dd")
 
 
@@ -312,9 +312,9 @@ def getDistance2D(x1, y1, x2, y2, isGeo=False, isDriving=False):
         distType = tc.REQUEST_DRIVINGDIST
     traci._beginMessage(
         tc.CMD_GET_SIM_VARIABLE, tc.DISTANCE_REQUEST, "", 1 + 4 + 1 + 8 + 8 + 1 + 8 + 8 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 3)
-    traci._message.string += struct.pack("!Bdd", posType, x1, y1)
-    traci._message.string += struct.pack("!BddB", posType, x2, y2, distType)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 3)
+    traci._message.string += struct_pack("!Bdd", posType, x1, y1)
+    traci._message.string += struct_pack("!BddB", posType, x2, y2, distType)
     return traci._checkResult(tc.CMD_GET_SIM_VARIABLE, tc.DISTANCE_REQUEST, "").readDouble()
 
 
@@ -328,12 +328,12 @@ def getDistanceRoad(edgeID1, pos1, edgeID2, pos2, isDriving=False):
         distType = tc.REQUEST_DRIVINGDIST
     traci._beginMessage(tc.CMD_GET_SIM_VARIABLE, tc.DISTANCE_REQUEST, "",
                         1 + 4 + 1 + 4 + len(edgeID1) + 8 + 1 + 1 + 4 + len(edgeID2) + 8 + 1 + 1)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 3)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 3)
+    traci._message.string += struct_pack("!Bi",
                                          tc.POSITION_ROADMAP, len(edgeID1)) + edgeID1
-    traci._message.string += struct.pack("!dBBi", pos1,
+    traci._message.string += struct_pack("!dBBi", pos1,
                                          0, tc.POSITION_ROADMAP, len(edgeID2)) + edgeID2
-    traci._message.string += struct.pack("!dBB", pos2, 0, distType)
+    traci._message.string += struct_pack("!dBB", pos2, 0, distType)
     return traci._checkResult(tc.CMD_GET_SIM_VARIABLE, tc.DISTANCE_REQUEST, "").readDouble()
 
 
@@ -358,6 +358,6 @@ def getSubscriptionResults():
 def clearPending(routeID=""):
     traci._beginMessage(tc.CMD_SET_SIM_VARIABLE, tc.CMD_CLEAR_PENDING_VEHICLES, "",
                         1 + 4 + len(routeID))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(routeID)) + str(routeID)
     traci._sendExact()

--- a/sumo/tools/traci/trafficlights.py
+++ b/sumo/tools/traci/trafficlights.py
@@ -16,9 +16,9 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
 
 
 class Phase:
@@ -273,23 +273,23 @@ def setCompleteRedYellowGreenDefinition(tlsID, tls):
         itemNo += 4
     traci._beginMessage(
         tc.CMD_SET_TL_VARIABLE, tc.TL_COMPLETE_PROGRAM_RYG, tlsID, length)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, itemNo)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, itemNo)
     # programID
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(tls._subID)) + str(tls._subID)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, 0)  # type
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, 0)  # type
     # subitems
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 0)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 0)
     # index
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_INTEGER, tls._currentPhaseIndex)
     # phaseNo
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_INTEGER, len(tls._phases))
     for p in tls._phases:
-        traci._message.string += struct.pack("!BiBiBi", tc.TYPE_INTEGER,
+        traci._message.string += struct_pack("!BiBiBi", tc.TYPE_INTEGER,
                                              p._duration, tc.TYPE_INTEGER, p._duration1, tc.TYPE_INTEGER, p._duration2)
-        traci._message.string += struct.pack("!Bi",
+        traci._message.string += struct_pack("!Bi",
                                              tc.TYPE_STRING, len(p._phaseDef)) + str(p._phaseDef)
     traci._sendExact()
 

--- a/sumo/tools/traci/vehicle.py
+++ b/sumo/tools/traci/vehicle.py
@@ -22,9 +22,10 @@ it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
-import struct
 import traci
 import traci.constants as tc
+from traci import struct_pack
+
 
 DEPART_TRIGGERED = -1
 DEPART_CONTAINER_TRIGGERED = -2
@@ -317,7 +318,7 @@ def getAdaptedTraveltime(vehID, time, edgeID):
     """
     traci._beginMessage(tc.CMD_GET_VEHICLE_VARIABLE,
                         tc.VAR_EDGE_TRAVELTIME, vehID, 1 + 4 + 1 + 4 + 1 + 4 + len(edgeID))
-    traci._message.string += struct.pack("!BiBiBi", tc.TYPE_COMPOUND, 2, tc.TYPE_INTEGER, time,
+    traci._message.string += struct_pack("!BiBiBi", tc.TYPE_COMPOUND, 2, tc.TYPE_INTEGER, time,
                                          tc.TYPE_STRING, len(edgeID)) + str(edgeID)
     return traci._checkResult(tc.CMD_GET_VEHICLE_VARIABLE, tc.VAR_EDGE_TRAVELTIME, vehID).readDouble()
 
@@ -329,7 +330,7 @@ def getEffort(vehID, time, edgeID):
     """
     traci._beginMessage(tc.CMD_GET_VEHICLE_VARIABLE,
                         tc.VAR_EDGE_EFFORT, vehID, 1 + 4 + 1 + 4 + 1 + 4 + len(edgeID))
-    traci._message.string += struct.pack("!BiBiBi", tc.TYPE_COMPOUND, 2, tc.TYPE_INTEGER, time,
+    traci._message.string += struct_pack("!BiBiBi", tc.TYPE_COMPOUND, 2, tc.TYPE_INTEGER, time,
                                          tc.TYPE_STRING, len(edgeID)) + str(edgeID)
     return traci._checkResult(tc.CMD_GET_VEHICLE_VARIABLE, tc.VAR_EDGE_EFFORT, vehID).readDouble()
 
@@ -483,7 +484,7 @@ def getLeader(vehID, dist=0.):
     """
     traci._beginMessage(
         tc.CMD_GET_VEHICLE_VARIABLE, tc.VAR_LEADER, vehID, 1 + 8)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, dist)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, dist)
     return _readLeader(traci._checkResult(tc.CMD_GET_VEHICLE_VARIABLE, tc.VAR_LEADER, vehID))
 
 
@@ -494,7 +495,7 @@ def subscribeLeader(vehID, dist=0., begin=0, end=2**31 - 1):
     The dist parameter defines the maximum lookahead, 0 calculates a lookahead from the brake gap.
     """
     traci._subscribe(tc.CMD_SUBSCRIBE_VEHICLE_VARIABLE, begin, end, vehID,
-                     (tc.VAR_LEADER,), {tc.VAR_LEADER: struct.pack("!Bd", tc.TYPE_DOUBLE, dist)})
+                     (tc.VAR_LEADER,), {tc.VAR_LEADER: struct_pack("!Bd", tc.TYPE_DOUBLE, dist)})
 
 
 def getDrivingDistance(vehID, edgeID, pos, laneID=0):
@@ -504,9 +505,9 @@ def getDrivingDistance(vehID, edgeID, pos, laneID=0):
     """
     traci._beginMessage(tc.CMD_GET_VEHICLE_VARIABLE, tc.DISTANCE_REQUEST,
                         vehID, 1 + 4 + 1 + 4 + len(edgeID) + 8 + 1 + 1)
-    traci._message.string += struct.pack("!BiBi", tc.TYPE_COMPOUND, 2,
+    traci._message.string += struct_pack("!BiBi", tc.TYPE_COMPOUND, 2,
                                          tc.POSITION_ROADMAP, len(edgeID)) + str(edgeID)
-    traci._message.string += struct.pack("!dBB",
+    traci._message.string += struct_pack("!dBB",
                                          pos, laneID, tc.REQUEST_DRIVINGDIST)
     return traci._checkResult(tc.CMD_GET_VEHICLE_VARIABLE, tc.DISTANCE_REQUEST, vehID).readDouble()
 
@@ -518,7 +519,7 @@ def getDrivingDistance2D(vehID, x, y):
     """
     traci._beginMessage(
         tc.CMD_GET_VEHICLE_VARIABLE, tc.DISTANCE_REQUEST, vehID, 1 + 4 + 1 + 8 + 8 + 1)
-    traci._message.string += struct.pack("!BiBddB", tc.TYPE_COMPOUND, 2,
+    traci._message.string += struct_pack("!BiBddB", tc.TYPE_COMPOUND, 2,
                                          tc.POSITION_2D, x, y, tc.REQUEST_DRIVINGDIST)
     return traci._checkResult(tc.CMD_GET_VEHICLE_VARIABLE, tc.DISTANCE_REQUEST, vehID).readDouble()
 
@@ -626,12 +627,12 @@ def setStop(vehID, edgeID, pos=1., laneIndex=0, duration=2**31 - 1, flags=STOP_D
     """
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_STOP,
                         vehID, 1 + 4 + 1 + 4 + len(edgeID) + 1 + 8 + 1 + 1 + 1 + 4 + 1 + 1 + 1 + 8 + 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 7)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 7)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(edgeID)) + str(edgeID)
-    traci._message.string += struct.pack("!BdBBBiBB", tc.TYPE_DOUBLE, pos,
+    traci._message.string += struct_pack("!BdBBBiBB", tc.TYPE_DOUBLE, pos,
                                          tc.TYPE_BYTE, laneIndex, tc.TYPE_INTEGER, duration, tc.TYPE_BYTE, flags)
-    traci._message.string += struct.pack("!BdBi",
+    traci._message.string += struct_pack("!BdBi",
                                          tc.TYPE_DOUBLE, startPos, tc.TYPE_INTEGER, until)
     traci._sendExact()
 
@@ -663,14 +664,14 @@ def resume(vehID):
     """
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_RESUME, vehID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 0)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 0)
     traci._sendExact()
 
 
 def changeLane(vehID, laneIndex, duration):
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_CHANGELANE, vehID, 1 + 4 + 1 + 1 + 1 + 4)
-    traci._message.string += struct.pack(
+    traci._message.string += struct_pack(
         "!BiBBBi", tc.TYPE_COMPOUND, 2, tc.TYPE_BYTE, laneIndex, tc.TYPE_INTEGER, duration)
     traci._sendExact()
 
@@ -678,7 +679,7 @@ def changeLane(vehID, laneIndex, duration):
 def slowDown(vehID, speed, duration):
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_SLOWDOWN, vehID, 1 + 4 + 1 + 8 + 1 + 4)
-    traci._message.string += struct.pack(
+    traci._message.string += struct_pack(
         "!BiBdBi", tc.TYPE_COMPOUND, 2, tc.TYPE_DOUBLE, speed, tc.TYPE_INTEGER, duration)
     traci._sendExact()
 
@@ -722,10 +723,10 @@ def setRoute(vehID, edgeList):
         edgeList = [edgeList]
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE, tc.VAR_ROUTE, vehID,
                         1 + 4 + sum(map(len, edgeList)) + 4 * len(edgeList))
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRINGLIST, len(edgeList))
     for edge in edgeList:
-        traci._message.string += struct.pack("!i", len(edge)) + str(edge)
+        traci._message.string += struct_pack("!i", len(edge)) + str(edge)
     traci._sendExact()
 
 
@@ -736,9 +737,9 @@ def setAdaptedTraveltime(vehID, begTime, endTime, edgeID, time):
     """
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE, tc.VAR_EDGE_TRAVELTIME,
                         vehID, 1 + 4 + 1 + 4 + 1 + 4 + 1 + 4 + len(edgeID) + 1 + 8)
-    traci._message.string += struct.pack("!BiBiBiBi", tc.TYPE_COMPOUND, 4, tc.TYPE_INTEGER, begTime,
+    traci._message.string += struct_pack("!BiBiBiBi", tc.TYPE_COMPOUND, 4, tc.TYPE_INTEGER, begTime,
                                          tc.TYPE_INTEGER, endTime, tc.TYPE_STRING, len(edgeID)) + str(edgeID)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, time)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, time)
     traci._sendExact()
 
 
@@ -749,9 +750,9 @@ def setEffort(vehID, begTime, endTime, edgeID, effort):
     """
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE, tc.VAR_EDGE_EFFORT,
                         vehID, 1 + 4 + 1 + 4 + 1 + 4 + 1 + 4 + len(edgeID) + 1 + 4)
-    traci._message.string += struct.pack("!BiBiBiBi", tc.TYPE_COMPOUND, 4, tc.TYPE_INTEGER, begTime,
+    traci._message.string += struct_pack("!BiBiBiBi", tc.TYPE_COMPOUND, 4, tc.TYPE_INTEGER, begTime,
                                          tc.TYPE_INTEGER, endTime, tc.TYPE_STRING, len(edgeID)) + str(edgeID)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, effort)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, effort)
     traci._sendExact()
 
 
@@ -767,14 +768,14 @@ def rerouteTraveltime(vehID, currentTravelTimes=True):
             traci.edge.adaptTraveltime(edge, traci.edge.getTraveltime(edge))
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_REROUTE_TRAVELTIME, vehID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 0)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 0)
     traci._sendExact()
 
 
 def rerouteEffort(vehID):
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.CMD_REROUTE_EFFORT, vehID, 1 + 4)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 0)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 0)
     traci._sendExact()
 
 
@@ -790,10 +791,10 @@ def setSignals(vehID, signals):
 def moveTo(vehID, laneID, pos):
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE,
                         tc.VAR_MOVE_TO, vehID, 1 + 4 + 1 + 4 + len(laneID) + 1 + 8)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 2)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(laneID)) + str(laneID)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, pos)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, pos)
     traci._sendExact()
 
 
@@ -814,7 +815,7 @@ def setColor(vehID, color):
     """
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.VAR_COLOR, vehID, 1 + 1 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
     traci._sendExact()
 
@@ -949,15 +950,15 @@ def add(vehID, routeID, depart=DEPART_NOW, pos=0, speed=0, lane=0, typeID="DEFAU
                         1 + 4 + 1 + 4 + len(typeID) + 1 + 4 + len(routeID) + 1 + 4 + 1 + 8 + 1 + 8 + 1 + 1)
     if depart > 0:
         depart *= 1000
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 6)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 6)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(typeID)) + str(typeID)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(routeID)) + str(routeID)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, depart)
-    traci._message.string += struct.pack("!BdBd",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, depart)
+    traci._message.string += struct_pack("!BdBd",
                                          tc.TYPE_DOUBLE, pos, tc.TYPE_DOUBLE, speed)
-    traci._message.string += struct.pack("!BB", tc.TYPE_BYTE, lane)
+    traci._message.string += struct_pack("!BB", tc.TYPE_BYTE, lane)
     traci._sendExact()
 
 
@@ -965,15 +966,15 @@ def addFull(vehID, routeID, typeID="DEFAULT_VEHTYPE", depart=None,
             departLane="0", departPos="base", departSpeed="0",
             arrivalLane="current", arrivalPos="max", arrivalSpeed="current",
             fromTaz="", toTaz="", line="", personCapacity=0, personNumber=0):
-    messageString = struct.pack("!Bi", tc.TYPE_COMPOUND, 14)
+    messageString = struct_pack("!Bi", tc.TYPE_COMPOUND, 14)
     if depart is None:
         depart = str(traci.simulation.getCurrentTime() / 1000.)
     for val in (routeID, typeID, depart, departLane, departPos, departSpeed,
                 arrivalLane, arrivalPos, arrivalSpeed, fromTaz, toTaz, line):
-        messageString += struct.pack("!Bi",
+        messageString += struct_pack("!Bi",
                                      tc.TYPE_STRING, len(val)) + str(val)
-    messageString += struct.pack("!Bi", tc.TYPE_INTEGER, personCapacity)
-    messageString += struct.pack("!Bi", tc.TYPE_INTEGER, personNumber)
+    messageString += struct_pack("!Bi", tc.TYPE_INTEGER, personCapacity)
+    messageString += struct_pack("!Bi", tc.TYPE_INTEGER, personNumber)
 
     traci._beginMessage(
         tc.CMD_SET_VEHICLE_VARIABLE, tc.ADD_FULL, vehID, len(messageString))
@@ -990,13 +991,13 @@ def remove(vehID, reason=tc.REMOVE_VAPORIZED):
 def moveToVTD(vehID, edgeID, lane, x, y, angle):
     traci._beginMessage(tc.CMD_SET_VEHICLE_VARIABLE, tc.VAR_MOVE_TO_VTD,
                         vehID, 1 + 4 + 1 + 4 + len(edgeID) + 1 + 4 + 1 + 8 + 1 + 8 + 1 + 8)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_COMPOUND, 5)
-    traci._message.string += struct.pack("!Bi",
+    traci._message.string += struct_pack("!Bi", tc.TYPE_COMPOUND, 5)
+    traci._message.string += struct_pack("!Bi",
                                          tc.TYPE_STRING, len(edgeID)) + str(edgeID)
-    traci._message.string += struct.pack("!Bi", tc.TYPE_INTEGER, lane)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, x)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, y)
-    traci._message.string += struct.pack("!Bd", tc.TYPE_DOUBLE, angle)
+    traci._message.string += struct_pack("!Bi", tc.TYPE_INTEGER, lane)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, x)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, y)
+    traci._message.string += struct_pack("!Bd", tc.TYPE_DOUBLE, angle)
     traci._sendExact()
 
 

--- a/sumo/tools/traci/vehicletype.py
+++ b/sumo/tools/traci/vehicletype.py
@@ -18,8 +18,9 @@ the Free Software Foundation; either version 3 of the License, or
 (at your option) any later version.
 """
 import traci
-import struct
 import traci.constants as tc
+from traci import struct_pack
+
 
 _RETURN_VALUE_FUNC = {tc.ID_LIST:             traci.Storage.readStringList,
                       tc.ID_COUNT:            traci.Storage.readInt,
@@ -329,7 +330,7 @@ def setColor(typeID, color):
     """
     traci._beginMessage(
         tc.CMD_SET_VEHICLETYPE_VARIABLE, tc.VAR_COLOR, typeID, 1 + 1 + 1 + 1 + 1)
-    traci._message.string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(
+    traci._message.string += struct_pack("!BBBBB", tc.TYPE_COLOR, int(
         color[0]), int(color[1]), int(color[2]), int(color[3]))
     traci._sendExact()
 


### PR DESCRIPTION
I have implemented Python 3 support for the latest TraCI Python API.
The changes are backward compatible with Python 2.

I've tested them with Python version 2.7, 3.2 and 3.4.

Please feel free to review the code and make any questions.
